### PR TITLE
Make tall flowers dragon immune by adding all flowers

### DIFF
--- a/Anti Ender Dragon Grief/data/minecraft/tags/blocks/dragon_immune.json
+++ b/Anti Ender Dragon Grief/data/minecraft/tags/blocks/dragon_immune.json
@@ -8,6 +8,7 @@
 		"#minecraft:enderman_holdable_original",
 		"#minecraft:fire",
 		"#minecraft:flower_pots",
+		"#minecraft:flowers",
 		"#minecraft:geode_invalid_blocks",
 		"#minecraft:glass_and_glass_panes",
 		"#minecraft:inside_step_sound_blocks",


### PR DESCRIPTION
The tall flowers like sunflower and lilac do not have the enderman_holdable tag to rely on. This patch adds all flowers to the immune list.